### PR TITLE
Improve JSX linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": "airbnb"
+  "extends": "airbnb",
+  "rules": {
+    "react/jsx-indent": [2, 2],
+    "react/no-deprecated": 2,
+    "react/prop-types": 1
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "exerking-front",
   "scripts": {
-    "lint": "eslint src/",
+    "lint": "eslint --ext .js,.jsx src/",
     "build": "webpack --config webpack.config.js",
     "postinstall": "webpack --config webpack.config.prod.js --progress --colors",
     "start": "node server.js",


### PR DESCRIPTION
Previously `*.jsx` files were not linted.
Also enables new `react/jsx-indent` rule not found in airbnb preset and adjusts few other.
